### PR TITLE
fix: value after first 2 characters can contains both number and character

### DIFF
--- a/src/Eori/EoriValidator.php
+++ b/src/Eori/EoriValidator.php
@@ -17,11 +17,6 @@ class EoriValidator
             return false;
         }
 
-        $number = substr($eori, 2);
-        if (!is_numeric($number)) {
-            return false;
-        }
-
         return true;
     }
 }

--- a/tests/unit/EoriValidatorTest.php
+++ b/tests/unit/EoriValidatorTest.php
@@ -14,7 +14,7 @@ class EoriValidatorTest extends \Codeception\Test\Unit
             ['eori' => 'DE', 'expected' => false],
             ['eori' => 'TH1234', 'expected' => false],
             ['eori' => 'DE11111111111111111111', 'expected' => false],
-            ['eori' => 'DEEE1111', 'expected' => false]
+            ['eori' => 'DEEE1111', 'expected' => true]
         ];
     }
 


### PR DESCRIPTION
closes https://crazyfactory.slack.com/archives/C4P7QGHCG/p1560320428023300

For long term solution, we will do this ticket https://zube.io/crazyfactory/crazy-factory/c/7233

It's in the current sprint right now.