### PR TITLE
feat: allow LV to have previx "LV-" and default zip code format len must < 10 chars

### DIFF
--- a/src/ZipCode/Validator.php
+++ b/src/ZipCode/Validator.php
@@ -59,7 +59,7 @@ class Validator
         'CY' => '[1-9]\\d{3}',
         'CZ' => '\\d{3}\\s\\d{2}',
         'DE' => '[0-9]{5}',
-        'DEFAULT' => '[0-9A-Z]',
+        'DEFAULT' => '[0-9A-Z]{1,10}',
         'DK' => '\\d{4}',
         'EE' => '[1-9]{1}[0-9]{4}',
         'ES' => '(AD{0,1}\\d{3})|\\d{5}',
@@ -73,7 +73,7 @@ class Validator
         'IT' => '\\d{5}',
         'LT' => '\\d{5}',
         'LU' => '[0-9]\\d{3}',
-        'LV' => '[1-9]{1}\\d{3}',
+        'LV' => '(LV-)?[1-9]{1}\\d{3}',
         'MC' => '98[0-9]{3}',
         'MT' => '[A-Z]{3}\\s[1-9]{1}[0-9]{3}',
         'NL' => '[1-9]\\d{3}\\s[A-Z]{2}',
@@ -111,13 +111,7 @@ class Validator
         ])) {
             return true;
         }
-
-        if (isset(static::FORMATS[$countryCode])) {
-            $regex = '/^' . static::FORMATS[$countryCode] . '$/';
-        }
-        else {
-            $regex = '/' . static::FORMATS['DEFAULT'] . '/';
-        }
+        $regex = '/^' . (static::FORMATS[$countryCode] ?? static::FORMATS['DEFAULT']) . '$/i';
 
         return preg_match($regex, $zipCode) > 0;
     }

--- a/tests/unit/ZipCodeTest.php
+++ b/tests/unit/ZipCodeTest.php
@@ -14,11 +14,16 @@ class ZipCodeTest extends \Codeception\Test\Unit
         $this->assertFalse(Validator::isValid('01234', 'LU'), 'LU');
         $this->assertFalse(Validator::isValid('01234', 'RO'), 'RO');
         $this->assertFalse(Validator::isValid('20207 MLINI', 'HR'), 'HR');
+        $this->assertFalse(Validator::isValid('12345678901', 'US'));
+
         $this->assertTrue(Validator::isValid('123456', 'RO'), 'RO');
         $this->assertTrue(Validator::isValid('01234', 'FR'), 'FR');
         $this->assertTrue(Validator::isValid('M6 6SD', 'GB'), 'GB: M6 6SD');
         $this->assertTrue(Validator::isValid('11111', 'HR'), 'HR: 11111');
         $this->assertTrue(Validator::isValid('0363', 'LU'), 'LU');
+        $this->assertTrue(Validator::isValid('1234567890', 'US'));
+        $this->assertTrue(Validator::isValid('LV-1111', 'LV'));
+        $this->assertTrue(Validator::isValid('1111', 'LV'));
 
         $noPostCodeCountries = ['AE', 'AU', 'BA', 'CO', 'QA'];
         foreach ($noPostCodeCountries as $country) {


### PR DESCRIPTION
- we still have invalid zip code error in Logistics. Most of them got error because it exceeds 10 length validation from Asendia API.
- additionally, we should allow "LV-" as prefix for LV country.